### PR TITLE
Clipboard fix

### DIFF
--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -135,5 +135,9 @@ export function processCommentBody(bodyHTML: string) {
     .querySelectorAll<HTMLAnchorElement>('a.commit-tease-sha')
     .forEach((a) => (a.href = 'https://github.com' + a.pathname));
 
+  content
+    .querySelectorAll<SVGElement>('svg.js-clipboard-check-icon')
+    .forEach((svg) => svg.classList.replace('d-sm-none', 'd-none'));
+
   return content.innerHTML;
 }

--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -113,7 +113,7 @@ export function handleClipboardCopy(event: ReactMouseEvent<HTMLDivElement, Mouse
     setTimeout(() => {
       clipboardIcon.classList.remove('d-none');
       checkIcon.classList.add('d-none');
-    }, 3000);
+    }, 2000);
   }
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -193,7 +193,7 @@ a {
 }
 
 .btn {
-  @apply relative inline-block whitespace-nowrap align-middle rounded-md;
+  @apply relative inline-block whitespace-nowrap align-middle rounded-md border cursor-pointer;
 }
 
 .btn .octicon {


### PR DESCRIPTION
GitHub recently rolled out the clipboard copy button to all code blocks. Previously (if I'm not mistaken), it's only enabled in discussions with QnA enabled.

With the rollout, they added the `d-sm-none` to `svg.js-clipboard-check-icon` by default. I really don't know why they did this, because it actually creates a visual bug on smaller screens when the button is not clicked yet:

![image](https://user-images.githubusercontent.com/6379424/117839569-8c696f00-b2a5-11eb-87d3-06d5909129a4.png)

This PR fixes that bug by replacing `d-sm-none` with `d-none`.

GitHub shouldn't have set the `d-block` class to `svg.js-clipboard-check-icon` by default. But, oh well..