### PR TITLE
Improve error handling and remove localStorage handling from the website

### DIFF
--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -162,8 +162,8 @@ export default function Configuration() {
             <>
               <XIcon className="inline-block ml-2 color-text-danger" />
               <p className="text-xs color-text-danger">
-                {`Couldn't`} use giscussions in this repository. Make sure all of the above criteria
-                has been met.
+                Cannot use giscussions in this repository. Make sure all of the above criteria has
+                been met.
               </p>
             </>
           ) : repositoryId && categories.length ? (

--- a/components/Configuration.tsx
+++ b/components/Configuration.tsx
@@ -80,7 +80,7 @@ export default function Configuration() {
   const [repository, setRepository] = useState('');
   const [repositoryId, setRepositoryId] = useState('');
   const [categoryId, setCategoryId] = useState('');
-  const [error, setError] = useState('');
+  const [error, setError] = useState(false);
   const [categories, setCategories] = useState<ICategory[]>([]);
   const [mapping, setMapping] = useState('pathname');
   const [term, setTerm] = useState('');
@@ -101,7 +101,7 @@ export default function Configuration() {
   }, [setGlobalTheme, theme]);
 
   useEffect(() => {
-    setError('');
+    setError(false);
     setRepositoryId('');
     setCategories([]);
     if (dRepository) {
@@ -109,12 +109,9 @@ export default function Configuration() {
         .then(({ repositoryId, categories }) => {
           setRepositoryId(repositoryId);
           setCategories(categories);
-          setError('');
         })
         .catch(() => {
-          setError(
-            `Couldn't use giscussions in this repository. Make sure all of the above criteria has been met.`,
-          );
+          setError(true);
         });
     }
   }, [dRepository]);
@@ -160,27 +157,32 @@ export default function Configuration() {
             className="my-2 px-[12px] py-[5px] min-w-[50%] form-control border rounded-md placeholder-gray-500"
             placeholder="owner/repo"
           />
-          {!error && !repositoryId && dRepository ? (
-            <SyncIcon className="inline-block ml-2 animate-spin" />
-          ) : null}
-          {!error && repositoryId && dRepository ? (
-            <CheckIcon className="inline-block ml-2 color-text-success" />
-          ) : null}
-          {error && !repositoryId && dRepository ? (
-            <XIcon className="inline-block ml-2 color-text-danger" />
-          ) : null}
 
-          {error ? (
-            <p className="text-xs color-text-danger">{error}</p>
-          ) : repositoryId ? (
-            <p className="text-xs color-text-success">
-              Success! This repository meets all of the above criteria.
-            </p>
+          {error || (repositoryId && !categories.length) ? (
+            <>
+              <XIcon className="inline-block ml-2 color-text-danger" />
+              <p className="text-xs color-text-danger">
+                {`Couldn't`} use giscussions in this repository. Make sure all of the above criteria
+                has been met.
+              </p>
+            </>
+          ) : repositoryId && categories.length ? (
+            <>
+              <CheckIcon className="inline-block ml-2 color-text-success" />
+              <p className="text-xs color-text-success">
+                Success! This repository meets all of the above criteria.
+              </p>
+            </>
           ) : (
-            <p className="text-xs color-text-secondary">
-              A <strong>public</strong> GitHub repository. This is where the discussions will be
-              linked to.
-            </p>
+            <>
+              {!error && !repositoryId && dRepository ? (
+                <SyncIcon className="inline-block ml-2 animate-spin" />
+              ) : null}
+              <p className="text-xs color-text-secondary">
+                A <strong>public</strong> GitHub repository. This is where the discussions will be
+                linked to.
+              </p>
+            </>
           )}
         </div>
       </fieldset>

--- a/components/Giscussions.tsx
+++ b/components/Giscussions.tsx
@@ -82,18 +82,18 @@ export default function Giscussions({
     backData?.discussion?.totalReplyCount +
     frontData?.reduce((prev, g) => prev + g.discussion.totalReplyCount, 0);
 
+  const error = frontError || backError;
+  const context = backData?.discussion?.repository?.nameWithOwner;
   const needsFrontLoading = backData?.discussion?.pageInfo?.hasPreviousPage;
 
   const isLoading = (needsFrontLoading && isFrontLoading) || isBackLoading;
   const isLoadingMore = isFrontLoading || (size > 0 && !frontData?.[size - 1]);
-  const isNotFound = !isBackLoading && !backData?.discussion;
+  const isNotFound = error?.status === 404;
 
-  const context = backData?.discussion?.repository?.nameWithOwner;
-
-  const error = frontError || backError;
   const shouldShowReplyCount = !error && !isNotFound && !isLoading;
+  const shouldShowCommentBox = !isLoading && (!error || (isNotFound && !number));
 
-  if (error && onError && !(error.status === 404)) onError();
+  if (error && onError && !isNotFound) onError();
 
   return (
     <div className="w-full color-text-primary">
@@ -188,7 +188,7 @@ export default function Giscussions({
 
       <div className="my-4 text-sm border-t-2 color-border-primary" />
 
-      {!isLoading ? (
+      {shouldShowCommentBox ? (
         <CommentBox
           viewer={backData?.viewer}
           discussionId={backData?.discussion?.id}

--- a/components/Giscussions.tsx
+++ b/components/Giscussions.tsx
@@ -8,7 +8,6 @@ interface IGiscussionsProps {
   repo: string;
   term?: string;
   number?: number;
-  onError?: VoidFunction;
   onDiscussionCreateRequest?: () => Promise<string>;
 }
 
@@ -16,7 +15,6 @@ export default function Giscussions({
   repo,
   term,
   number,
-  onError,
   onDiscussionCreateRequest,
 }: IGiscussionsProps) {
   const { token } = useContext(AuthContext);
@@ -92,8 +90,6 @@ export default function Giscussions({
 
   const shouldShowReplyCount = !error && !isNotFound && !isLoading;
   const shouldShowCommentBox = !isLoading && (!error || (isNotFound && !number));
-
-  if (error && onError && !isNotFound) onError();
 
   return (
     <div className="w-full color-text-primary">

--- a/components/Giscussions.tsx
+++ b/components/Giscussions.tsx
@@ -93,7 +93,7 @@ export default function Giscussions({
   const error = frontError || backError;
   const shouldShowReplyCount = !error && !isNotFound && !isLoading;
 
-  if (error && onError) onError();
+  if (error && onError && !(error.status === 404)) onError();
 
   return (
     <div className="w-full color-text-primary">

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -18,24 +18,15 @@ interface IWidgetProps {
 }
 
 function getSession(router: NextRouter) {
-  let savedSession: string;
-  try {
-    savedSession = JSON.parse(localStorage.getItem(GISCUSSIONS_SESSION_KEY));
-  } catch (err) {
-    savedSession = '';
-  }
-
-  const querySession = router.query.session as string;
-  if (querySession) {
-    localStorage.setItem(GISCUSSIONS_SESSION_KEY, JSON.stringify(querySession));
+  const session = router.query.session as string;
+  if (session) {
     const query = { ...router.query };
     delete query.session;
     const url = { pathname: router.pathname, query };
     const options = { scroll: false, shallow: true };
     router.replace(url, undefined, options);
   }
-
-  return querySession || savedSession;
+  return session || '';
 }
 
 export default function Widget({

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -28,6 +28,11 @@ function getSession(router: NextRouter) {
   const querySession = router.query.session as string;
   if (querySession) {
     localStorage.setItem(GISCUSSIONS_SESSION_KEY, JSON.stringify(querySession));
+    const query = { ...router.query };
+    delete query.session;
+    const url = { pathname: router.pathname, query };
+    const options = { scroll: false, shallow: true };
+    router.replace(url, undefined, options);
   }
 
   return querySession || savedSession;

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -1,12 +1,10 @@
 import { NextRouter, useRouter } from 'next/router';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import Giscussions from '../components/Giscussions';
 import { AuthContext } from '../lib/context';
 import { useIsMounted } from '../lib/hooks';
 import { createDiscussion } from '../services/giscussions/createDiscussion';
 import { getToken } from '../services/giscussions/token';
-
-const GISCUSSIONS_SESSION_KEY = 'giscussions-session';
 
 interface IWidgetProps {
   repo: string;
@@ -45,21 +43,12 @@ export default function Widget({
   const session = getSession(router);
   const origin = (router.query.origin as string) || (isMounted ? location.href : '');
 
-  const handleError = useCallback(() => {
-    if (localStorage.getItem(GISCUSSIONS_SESSION_KEY) !== null) {
-      localStorage.removeItem(GISCUSSIONS_SESSION_KEY);
-      router.reload();
-    }
-  }, [router]);
-
   if (!isFetchingToken && session && !token) {
     setIsFetchingToken(true);
-    getToken(session)
-      .then((token) => {
-        setToken(token);
-        setIsFetchingToken(false);
-      })
-      .catch(handleError);
+    getToken(session).then((token) => {
+      setToken(token);
+      setIsFetchingToken(false);
+    });
   }
 
   const handleDiscussionCreateRequest = async () =>
@@ -78,7 +67,6 @@ export default function Widget({
         repo={repo}
         term={term}
         number={number}
-        onError={handleError}
         onDiscussionCreateRequest={handleDiscussionCreateRequest}
       />
     </AuthContext.Provider>

--- a/pages/api/discussions/index.ts
+++ b/pages/api/discussions/index.ts
@@ -59,7 +59,16 @@ async function get(req: NextApiRequest, res: NextApiResponse<IGiscussion | { err
 
 async function post(req: NextApiRequest, res: NextApiResponse<{ id: string } | { error: string }>) {
   const { repo, input } = req.body;
-  const response = await createDiscussion(repo, { input });
+
+  let token: string;
+  try {
+    token = await getAppAccessToken(repo);
+  } catch (error) {
+    res.status(403).json({ error: error.message });
+    return;
+  }
+
+  const response = await createDiscussion(repo, token, { input });
   const id = response?.data?.createDiscussion?.discussion?.id;
 
   if (!id) {

--- a/services/github/createDiscussion.ts
+++ b/services/github/createDiscussion.ts
@@ -1,5 +1,4 @@
 import { GCreateDiscussionInput } from '../../lib/types/github';
-import { getAppAccessToken } from './getAppAccessToken';
 
 const GITHUB_API_URL = 'https://api.github.com/graphql';
 
@@ -28,12 +27,13 @@ export interface CreateDiscussionResponse {
 
 export async function createDiscussion(
   repoWithOwner: string,
+  token: string,
   params: CreateDiscussionBody,
 ): Promise<CreateDiscussionResponse> {
   return fetch(GITHUB_API_URL, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${await getAppAccessToken(repoWithOwner)}`,
+      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       'GraphQL-Features': 'discussions_api',
     },


### PR DESCRIPTION
The `localStorage` handling should only be handled by the client script during the `<iframe>` initialization. There's no point of handling it on giscussions' website. It would even trigger unexpected problems.

Part of #39, but I'm sure there are still other places where we can improve the handling.